### PR TITLE
handle tab and comma separated files in docker

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,13 +2,22 @@
 set -e
 set -u
 
-# first have to sort the input rows 
-# by sample, chromosome, then position _numerically_ i.e. 1,2,10
-# after conversion, sort again (?)
+# arg 1 is the input s3 url
+# arg 2 is the output s3 url
+# args other are passed to illumina2vcf
 
+# first have to sort the input rows
+# by sample, chromosome, then position _numerically_ i.e. 1,2,10
+# do conversion, then sort again (not needed?)
+# generate tabix index of output
+
+# use funzip to stream unzip without needing the file list at end of zip archive
+# replace commas to tab incase of comma separated input
+# sort by chromosome, position, probe num, samplenum
 { aws s3 cp $1 - | funzip | head; \
   aws s3 cp $1 - | funzip | tail -n+11 \
-  | grep -v NA12878 | sort -Vt , -k 9 -k 10 -k 4 -k 5
+  | sed 's/\,/\t/g' \
+  | sort -V -k9,10 -k4,5
 } | python3.9 -m illumina2vcf ${@:3} | bcftools sort -Oz | aws s3 cp - $2
 
 s3role tabix $2


### PR DESCRIPTION
Fix the docker scripts handling of pre-sorting to handle both comma and tab separated files. It does this by replacing commas with tabs, which isn't ideal as it won't work for files with commas within columns but that shouldn't happen.