### PR TITLE
only handle tab separated via docker

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,7 +8,7 @@ set -u
 
 # first have to sort the input rows
 # by sample, chromosome, then position _numerically_ i.e. 1,2,10
-# do conversion, then sort again 
+# do conversion, then sort again
 # generate tabix index of output
 
 # use funzip to stream unzip without needing the file list at end of zip archive


### PR DESCRIPTION
You were right @hobrien - there are commas used in the id field, so we can't do a bulk replace.

I think we can not support comma-separate illumina files. It was only the GDA+NB pilot that used them I think? And in future we can insist on proper tab-separated files.