### PR TITLE
fix reference file in test label

### DIFF
--- a/docker/Dockerfile.ref
+++ b/docker/Dockerfile.ref
@@ -15,7 +15,7 @@ RUN curl "https://storage.googleapis.com/genomics-public-data/resources/broad/hg
 # now copy the references into the final image
 # do this to use docker layer caching to cache the downloaded reference information
 
-FROM sanogenetics/illumina2vcf:latest
+FROM illumina2vcf:latest
 
 WORKDIR /app
 RUN mkdir ref

--- a/docker/Dockerfile.test-ref
+++ b/docker/Dockerfile.test-ref
@@ -1,37 +1,26 @@
-# use base image that already has AWS CLI & HTSLIB+SAMTools+VCFTools
-FROM sanogenetics/htslib-bcftools-samtools:latest as ref
-
+# use the image that already has the full reference downloaded
+FROM illumina2vcf:latest-ref as ref
 WORKDIR /app
 
-# install subset of reference genome - ~3GB download and ~500KB kept
+# install subset of reference genome - ~3GB download and ~5MB kept
 # chr1,2,10 for chromosome ordering and autosomal testing
 # chrX,Y for sex chromosome and PAR testing
 # chrM for mitochondial chromosome testing
 # useful for downstream testing purposes
-# Docker ADD always downloads to verify cache
-RUN mkdir ref
-RUN apt-get update && apt-get install -y libssl-dev
-RUN samtools faidx -o ref/Homo_sapiens_assembly38.fasta \
-  'https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Homo_sapiens_assembly38.fasta' \
-  chr1:0-1000000 \
-  chr2:0-1000000 \
-  chr10:0-1000000 \
-  chrX:0-3000000 \
-  chrY:0-3000000 \
-  chrM
-RUN samtools faidx ref/Homo_sapiens_assembly38.fasta
+RUN samtools faidx ref/Homo_sapiens_assembly38.fasta -o ref/Homo_sapiens_assembly38.trim.fasta chr1:1-1000000 chr2:1-1000000 chr10:1-1000000 chrX:1-3000000 chrY:1-3000000 chrM
+RUN samtools faidx ref/Homo_sapiens_assembly38.trim.fasta
 
 
 # now copy the references into the final image
 # do this to use docker layer caching to cache the downloaded reference information
 
-FROM sanogenetics/illumina2vcf:latest
+FROM illumina2vcf:latest
 
 WORKDIR /app
 RUN mkdir ref
 
-COPY --from=ref /app/ref/Homo_sapiens_assembly38.fasta ref/Homo_sapiens_assembly38.fasta
-COPY --from=ref /app/ref/Homo_sapiens_assembly38.fasta.fai ref/Homo_sapiens_assembly38.fasta.fai
+COPY --from=ref /app/ref/Homo_sapiens_assembly38.trim.fasta ref/Homo_sapiens_assembly38.fasta
+COPY --from=ref /app/ref/Homo_sapiens_assembly38.trim.fasta.fai ref/Homo_sapiens_assembly38.fasta.fai
 
 # install reference extras
 COPY ref/GSAMD-24v3-0-EA_20034606_A2_blocklist.txt ref/


### PR DESCRIPTION
`samtools faidx` is 1-based so the reference for testing was only the mitochondrial DNA which wasnt useful.

This fixes it to be 1MB of chr1,2,10 plus 3MB chrX,Y as intended.

Also improves image building by basing the trimmed reference off the full reference, thus avoiding downloading it twice.