### PR TITLE
fix test file sequence naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ unzip -p FinalReport.zip | tail -n+11 | grep -v NA12878 | sort -Vt , -k 9 -k 10 
 Running the script is done like:
 
 ```sh
-gunzip -c input.txt.gz | python3 -m illumina2vcf --fasta Homo_sapiens_assembly38.fasta --tab | bgzip > output.vcf.gz
+gunzip -c input.txt.gz | python3 -m illumina2vcf --tab Homo_sapiens_assembly38.fasta | bgzip > output.vcf.gz
 ```
 
 Polishing includes resorting (chrX SNPs out of order because chrXY get converted to chrX) and tabix indexing
@@ -44,8 +44,8 @@ Note these steps can be piped together
 ```sh
 { unzip -p FinalReport.zip | head; \
   unzip -p FinalReport.zip | tail -n+11 \
-  | grep -v NA12878 | sort -Vt , -k 9 -k 10 -k 4 -k 5 \
- } | python3 -m illumina2vcf --fasta Homo_sapiens_assembly38.fasta --tab \
+  | grep -v NA12878 | sort -Vt , -k 9 -k 10 -k 4 -k 5 ; \
+ } | python3 -m illumina2vcf ----tab Homo_sapiens_assembly38.fasta \
 | bcftools sort -Oz > out.vcf.gz
 ```
 

--- a/docker/Dockerfile.test-ref
+++ b/docker/Dockerfile.test-ref
@@ -5,9 +5,9 @@ WORKDIR /app
 # install subset of reference genome - ~3GB download and ~5MB kept
 # chr1,2,10 for chromosome ordering and autosomal testing
 # chrX,Y for sex chromosome and PAR testing
-# chrM for mitochondial chromosome testing
 # useful for downstream testing purposes
-RUN samtools faidx ref/Homo_sapiens_assembly38.fasta -o ref/Homo_sapiens_assembly38.trim.fasta chr1:1-1000000 chr2:1-1000000 chr10:1-1000000 chrX:1-3000000 chrY:1-3000000 chrM
+# when using a region with samtools faidx it renames the sequence, we need to undo that
+RUN samtools faidx ref/Homo_sapiens_assembly38.fasta 'chr1:1-1000000' 'chr2:1-1000000' 'chr10:1-1000000' 'chrX:1-3000000' 'chrY:1-3000000' | sed 's/:1-[0-9]*//' >ref/Homo_sapiens_assembly38.trim.fasta
 RUN samtools faidx ref/Homo_sapiens_assembly38.trim.fasta
 
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -31,10 +31,6 @@ else
 fi
 
 # sort by chromosome, position, probe num, samplenum
-{
-  aws $AWS_CLI_ARGS s3 cp $1 - | $DECOMPRESSOR | head
-  aws $AWS_CLI_ARGS s3 cp $1 - | $DECOMPRESSOR | tail -n+11 |
-    sort -V -k9,10 -k4,5
-} | python3.9 -m illumina2vcf ${@:3} | bcftools sort -Oz | aws $AWS_CLI_ARGS s3 cp - $2
+{ aws $AWS_CLI_ARGS s3 cp $1 - | $DECOMPRESSOR | head ; aws $AWS_CLI_ARGS s3 cp $1 - | $DECOMPRESSOR | tail -n+11 | sort -V -k9,10 -k4,5 ; } | python3.9 -m illumina2vcf ${@:3} | bcftools sort -Oz | aws $AWS_CLI_ARGS s3 cp - $2
 
 s3role tabix $2


### PR DESCRIPTION
Using `samtools faidx` to get a region also renames the sequences. This undoes that step to keep chromosome names as expected on test reference data.