### PR TITLE
fix dockerfile test data generation, improve testing

### DIFF
--- a/docker/Dockerfile.test-ref
+++ b/docker/Dockerfile.test-ref
@@ -14,12 +14,11 @@ RUN samtools faidx ref/Homo_sapiens_assembly38.trim.fasta
 # reduce manifest file in the same way
 # keep the header
 # filter only to specific chrom,pos
-RUN gunzip -c ref/GSA-24v3-0_A2.csv.gz | head -n 8 > ref/GSA-24v3-0_A2.trim.csv \
+RUN gunzip -c ref/GSA-24v3-0_A2.csv.gz | head -n 8 >ref/GSA-24v3-0_A2.trim.csv \
   && gunzip -c ref/GSA-24v3-0_A2.csv.gz \
   | grep -E '(,38,1,)|(,38,2,)|(,38,10,)|(,38,X,)|(,38,Y,)' \
-  | awk -F',' '$11<3000000' \
-  | gzip \
-  >> ref/GSA-24v3-0_A2.trim.csv.gz
+  | awk -F',' '$11<3000000' >>ref/GSA-24v3-0_A2.trim.csv\
+  && gzip ref/GSA-24v3-0_A2.trim.csv
 
 # now copy the references into the final image
 # do this to use docker layer caching to cache the downloaded reference information

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -96,6 +96,13 @@ class TestVCF:
         """
         THEN it should produce valid output
         """
+
+        # pick out some specific ones that we know what to expect
+        rsidlines = {
+            "rs9651229": None,  # SNP
+            "rs797044837": None,  # deletion
+            "rs61750435": None,  # insertion
+        }
         maxref = 0
         maxalt = 0
         for line in lines:
@@ -107,5 +114,13 @@ class TestVCF:
             assert len(line.sample) == 1
             maxref = max(maxref, len(line.ref))
             maxalt = max(maxalt, max((len(i) for i in line.alt)))
+
+            if line._id[0] in rsidlines.keys():
+                rsid = line._id[0]
+                assert not rsidlines[rsid]
+                rsidlines[rsid] = line
         assert maxref > 1
         assert maxalt > 1
+
+        for key in rsidlines:
+            assert rsidlines[key]


### PR DESCRIPTION
Fixes an issue with the test reference data generation - was putting header in one file, and compressed body in another. Now puts compressed header and body together, which actually works.

Also adds some additional testing that helped to identify the cause of this issue.