### PR TITLE
Hotfix/correct insertion pos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test_data/
+ref/
 in/
 venv/
 *.vcf.gz

--- a/README.md
+++ b/README.md
@@ -17,28 +17,28 @@ this is necessary because the vcf has multiple samples on each row
 get the header that won't be sorted:
 
 ```sh
-unzip -p FinalReport.zip | head | gzip > input.csv.gz
+unzip -p FinalReport.zip | head | gzip > input.tsv.gz
 ```
 
 get and sort the rest, removing reference sample on the way.
 - this should be sorted correctly, except that chrMT will come before chrX, chrY and chrXY
 
 ```sh
-unzip -p FinalReport.zip | tail -n+11 | grep -v NA12878 | sort -Vt , -k 9 -k 10 -k 4 -k 5 | gzip >> input.csv.gz
+unzip -p FinalReport.zip | tail -n+11 | grep -v NA12878 | sort -Vt , -k 9 -k 10 -k 4 -k 5 | gzip >> input.tsv.gz
 ```
 
 Running the script is done like:
 
 ```sh
 
-gunzip -c input.txt.gz | python3 -m illumina2vcf --manifest GSA-24v3-0_A2.csv --tab Homo_sapiens_assembly38.fasta | bgzip > output.vcf.gz
+gunzip -c input.tsv.gz | python3 -m illumina2vcf --manifest GSA-24v3-0_A2.csv --tab Homo_sapiens_assembly38.fasta | bgzip > output.vcf.gz
 
 ```
 
 Polishing includes resorting (chrX SNPs out of order because chrXY get converted to chrX) and tabix indexing
 
 ```sh
-bcftools sort out.vcf.gz | bcftools view -s ^NA12878 --no-version --no-update -Oz > out.clean.vcf.gz
+bcftools sort output.vcf.gz | bcftools view -s ^NA12878 --no-version --no-update -Oz > out.clean.vcf.gz
 tabix out.clean.vcf.gz
 ```
 

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -153,11 +153,11 @@ class VCFMaker:
                 # get the records in the manifest for this locaion
                 locus_records = self._indel_records[(chm, pos)]
 
-                (ref, alt) = self.get_alleles_for_indel(locus_records[0])
+                (ref, alt, pos) = self.get_alleles_for_indel(locus_records[0])
 
                 # check the other lotus records have the same reference + alternative alleles
                 for alt_record in locus_records[1:]:
-                    if (ref, alt) != self.get_alleles_for_indel(alt_record):
+                    if (ref, alt, pos) != self.get_alleles_for_indel(alt_record):
                         raise ConverterError(
                             f"{';'.join(snp_names)}: Mismatched alleles ({','.join(probed)}) {block[0].chrom}:{block[0].pos}"
                         )
@@ -240,14 +240,17 @@ class VCFMaker:
             chrom = "X"
 
         if bpm_record.is_deletion:
+
             reference_base = self._genome_reader.get_reference_bases(chrom, start_index - 1, start_index)
             reference_allele = reference_base + indel_sequence
             alternate_allele = reference_base
+            pos = bpm_record.pos
         else:
             reference_base = self._genome_reader.get_reference_bases(chrom, start_index, start_index + 1)
             reference_allele = reference_base
             alternate_allele = reference_base + indel_sequence
-        return (reference_allele, alternate_allele)
+            pos = bpm_record.pos + 1
+        return (reference_allele, alternate_allele, pos)
 
     def format_vcf_genotype(self, vcf_allele1_char, vcf_allele2_char):
         """

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -103,6 +103,11 @@ class TestVCF:
             "rs797044837": None,  # deletion
             "rs61750435": None,  # insertion
         }
+        variant_info = {
+            "rs9651229": "chr1-632287-C-T",
+            "rs797044837": "chr1-1338000-CT-C",
+            "rs61750435": "chr1-2406791-C-CT",
+        }
         maxref = 0
         maxalt = 0
         for line in lines:
@@ -117,6 +122,7 @@ class TestVCF:
 
             if line._id[0] in rsidlines.keys():
                 rsid = line._id[0]
+                assert variant_info[rsid] == "-".join([line.chrom, str(line.pos), line.ref, line.alt[0]])
                 assert not rsidlines[rsid]
                 rsidlines[rsid] = line
         assert maxref > 1


### PR DESCRIPTION
For deletions, POS should be set to the base _before_ the deletion so that the ALT allele is not an empty string. For insertions, POS is the matches the position of the insertion. This script was subtracting 1 base from POS for all indels. This PR changes this to only subtract for deletions. The easiest way to do this was to calculate pos in the function that determines the REF and ALT values. I also added an assertion to the test that checks the chrom, pos, ref, and alt of the vcf line against the corresponding values in GnomAD.