### PR TITLE
Feature/report qc stats

### DIFF
--- a/illumina2vcf/__init__.py
+++ b/illumina2vcf/__init__.py
@@ -58,9 +58,7 @@ class Converter:
         blocks = reader.generate_line_blocks(source)
 
         # generate vcf lines and qc info
-        vcf_lines = []
-        for line in vcfgenerator.generate_lines(blocks):
-            vcf_lines.append(line)
+        vcf_lines = [line for line in vcfgenerator.generate_lines(blocks)]
 
         # write header
         for line in vcfgenerator.generate_header(date, header_source, self.buildname):

--- a/illumina2vcf/__init__.py
+++ b/illumina2vcf/__init__.py
@@ -54,15 +54,20 @@ class Converter:
         # read source header
         date, header_source = reader.parse_header(source)
 
+        # read source blocks
+        blocks = reader.generate_line_blocks(source)
+
+        # generate vcf lines and qc info
+        vcf_lines = []
+        for line in vcfgenerator.generate_lines(blocks):
+            vcf_lines.append(line)
+
         # write header
         for line in vcfgenerator.generate_header(date, header_source, self.buildname):
             destination.write(str(line))
             destination.write("\n")
 
-        # read source blocks
-        blocks = reader.generate_line_blocks(source)
-
         # write vcf lines
-        for line in vcfgenerator.generate_lines(blocks):
+        for line in vcf_lines:
             destination.write(str(line))
             destination.write("\n")

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -88,10 +88,12 @@ class VCFMaker:
                     {"ID": chrom, "length": rec.rlen, "assembly": buildname},
                 )
         # ##qc_stats=<callrate=0.99,het=0.33,x_het=0.21,y_notnull=0.24>
-        yield VCFLine.as_comment_key_dict(
-            "qc_stats",
-            {stat: value for (stat, value) in self._calculate_qc_stats()},
-        )
+        qc_stats = {stat: value for (stat, value) in self._calculate_qc_stats()}
+        if qc_stats:
+            yield VCFLine.as_comment_key_dict(
+                "qc_stats",
+                qc_stats,
+            )
 
     def generate_lines(self, blocks: Iterable[List[IlluminaRow]]) -> Generator[VCFLine, None, None]:
         column_header = False

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Dict, Generator, Iterable, List, Tuple
+from typing import Dict, Generator, Iterable, List, Literal, Tuple
 
 from puretabix.vcf import VCFLine
 
@@ -18,6 +18,77 @@ class ConverterError(Exception):
     pass
 
 
+class QC_stats:
+    def __init__(self):
+        self.vcf_lines_autosomal = 0
+        self.called_lines_autosomal = 0
+        self.heterozygous_lines_autosomal = 0
+        self.called_lines_x = 0
+        self.heterozygous_lines_x = 0
+        self.vcf_lines_y = 0
+        self.called_lines_y = 0
+
+    def vcf_comment(self) -> str:
+        qc_stats = {}
+        try:
+            qc_stats["callrate"] = self.call_rate("autosomal")
+        except ZeroDivisionError:
+            pass
+        try:
+            qc_stats["y_notnull"] = self.call_rate("Y")
+        except ZeroDivisionError:
+            pass
+        try:
+            qc_stats["het"] = self.heterozygosity("autosomal")
+        except ZeroDivisionError:
+            pass
+        try:
+            qc_stats["x_het"] = self.heterozygosity("X")
+        except ZeroDivisionError:
+            pass
+        if qc_stats:
+            return VCFLine.as_comment_key_dict("qc_stats", qc_stats)
+        else:
+            pass
+
+    def call_rate(self, chrom: Literal["autosomal", "Y"]) -> float:
+        if chrom == "autosomal":
+            return "{0:.2f}".format(self.called_lines_autosomal / self.vcf_lines_autosomal)
+        elif chrom == "Y":
+            return "{0:.2f}".format(self.called_lines_y / self.vcf_lines_y)
+        else:
+            raise NotImplementedError(f"cannot calculate call rate for chrom {chrom}")
+
+    def heterozygosity(self, chrom: Literal["autosomal", "X"]) -> float:
+        if chrom == "autosomal":
+            return "{0:.2f}".format(self.heterozygous_lines_autosomal / self.called_lines_autosomal)
+        elif chrom == "X":
+            return "{0:.2f}".format(self.heterozygous_lines_x / self.called_lines_x)
+        else:
+            raise NotImplementedError(f"cannot calculate heterozygosity for chrom {chrom}")
+
+    def _update_qc_stats(self, vcfline: VCFLine) -> None:
+        gt = vcfline.sample[0]["GT"]
+        chm = vcfline.chrom
+        if chm == "chrX":
+            if gt != "./.":
+                self.called_lines_x += 1
+                if len(set(gt.split("/"))) == 2:
+                    self.heterozygous_lines_x += 1
+        elif chm == "chrY":
+            self.vcf_lines_y += 1
+            if gt != "./.":
+                self.called_lines_y += 1
+        elif chm == "chrM":
+            pass
+        else:
+            self.vcf_lines_autosomal += 1
+            if gt != "./.":
+                self.called_lines_autosomal += 1
+                if len(set(gt.split("/"))) == 2:
+                    self.heterozygous_lines_autosomal += 1
+
+
 class VCFMaker:
     _genome_reader: ReferenceGenome
     _indel_records: Dict
@@ -25,40 +96,11 @@ class VCFMaker:
     def __init__(self, genome_reader: ReferenceGenome, indel_records: Dict = {}):
         self._genome_reader = genome_reader
         self._indel_records = indel_records
-        self.qc_stats = {
-            "vcf_lines_autosomal": 0,
-            "called_lines_autosomal": 0,
-            "heterozygous_lines_autosomal": 0,
-            "called_lines_x": 0,
-            "heterozygous_lines_x": 0,
-            "vcf_lines_y": 0,
-            "called_lines_y": 0,
-        }
+        self.qc_stats = QC_stats()
 
     @staticmethod
     def is_valid_chromosome(chrom: str) -> bool:
         return bool(re.match(r"^chr[1-9XYM][0-9]?$", chrom))
-
-    def _calculate_qc_stats(self):
-        if self.qc_stats["vcf_lines_autosomal"] > 0:
-            yield (
-                "callrate",
-                "{0:.2f}".format(self.qc_stats["called_lines_autosomal"] / self.qc_stats["vcf_lines_autosomal"]),
-            )
-
-        if self.qc_stats["called_lines_autosomal"] > 0:
-            yield (
-                "het",
-                "{0:.2f}".format(
-                    self.qc_stats["heterozygous_lines_autosomal"] / self.qc_stats["called_lines_autosomal"]
-                ),
-            )
-
-        if self.qc_stats["called_lines_x"] > 0:
-            yield ("x_het", "{0:.2f}".format(self.qc_stats["heterozygous_lines_x"] / self.qc_stats["called_lines_x"]))
-
-        if self.qc_stats["vcf_lines_y"] > 0:
-            yield ("y_notnull", "{0:.2f}".format(self.qc_stats["called_lines_y"] / self.qc_stats["vcf_lines_y"]))
 
     def generate_header(self, date: str, source: str, buildname: str) -> Generator[VCFLine, None, None]:
         # write header
@@ -88,12 +130,9 @@ class VCFMaker:
                     {"ID": chrom, "length": rec.rlen, "assembly": buildname},
                 )
         # ##qc_stats=<callrate=0.99,het=0.33,x_het=0.21,y_notnull=0.24>
-        qc_stats = {stat: value for (stat, value) in self._calculate_qc_stats()}
+        qc_stats = self.qc_stats.vcf_comment()
         if qc_stats:
-            yield VCFLine.as_comment_key_dict(
-                "qc_stats",
-                qc_stats,
-            )
+            yield qc_stats
 
     def generate_lines(self, blocks: Iterable[List[IlluminaRow]]) -> Generator[VCFLine, None, None]:
         column_header = False
@@ -255,28 +294,11 @@ class VCFMaker:
         for sampleid in sample_set:
             samples.append({"GT": converted_calls.get(sampleid, "./.")})
 
+        vcfline = VCFLine("", "", "", {}, chm, pos, snp_names, ref, alt, ".", ["PASS"], {}, samples)
+
         # update qc totals if single sample
         if len(samples) == 1:
-            gt = samples[0]["GT"]
-            if chm == "chrX":
-                if gt != "./.":
-                    self.qc_stats["called_lines_x"] += 1
-                    if len(set(gt.split("/"))) == 2:
-                        self.qc_stats["heterozygous_lines_x"] += 1
-            elif chm == "chrY":
-                self.qc_stats["vcf_lines_y"] += 1
-                if gt != "./.":
-                    self.qc_stats["called_lines_y"] += 1
-            elif chm == "chrM":
-                pass
-            else:
-                self.qc_stats["vcf_lines_autosomal"] += 1
-                if gt != "./.":
-                    self.qc_stats["called_lines_autosomal"] += 1
-                    if len(set(gt.split("/"))) == 2:
-                        self.qc_stats["heterozygous_lines_autosomal"] += 1
-
-        vcfline = VCFLine("", "", "", {}, chm, pos, snp_names, ref, alt, ".", ["PASS"], {}, samples)
+            self.qc_stats._update_qc_stats(vcfline)
 
         return vcfline
 

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -31,19 +31,19 @@ class QC_stats:
     def vcf_comment(self) -> str:
         qc_stats = {}
         try:
-            qc_stats["callrate"] = self.call_rate("autosomal")
+            qc_stats["callrate"] = f"{self.call_rate('autosomal'):.2f}"
         except ZeroDivisionError:
             pass
         try:
-            qc_stats["y_notnull"] = self.call_rate("Y")
+            qc_stats["y_notnull"] = f"{self.call_rate('Y'):.2f}"
         except ZeroDivisionError:
             pass
         try:
-            qc_stats["het"] = self.heterozygosity("autosomal")
+            qc_stats["het"] = f"{self.heterozygosity('autosomal'):.2f}"
         except ZeroDivisionError:
             pass
         try:
-            qc_stats["x_het"] = self.heterozygosity("X")
+            qc_stats["x_het"] = f"{self.heterozygosity('X'):.2f}"
         except ZeroDivisionError:
             pass
         if qc_stats:
@@ -53,17 +53,17 @@ class QC_stats:
 
     def call_rate(self, chrom: Literal["autosomal", "Y"]) -> float:
         if chrom == "autosomal":
-            return "{0:.2f}".format(self.called_lines_autosomal / self.vcf_lines_autosomal)
+            return self.called_lines_autosomal / self.vcf_lines_autosomal
         elif chrom == "Y":
-            return "{0:.2f}".format(self.called_lines_y / self.vcf_lines_y)
+            return self.called_lines_y / self.vcf_lines_y
         else:
             raise NotImplementedError(f"cannot calculate call rate for chrom {chrom}")
 
     def heterozygosity(self, chrom: Literal["autosomal", "X"]) -> float:
         if chrom == "autosomal":
-            return "{0:.2f}".format(self.heterozygous_lines_autosomal / self.called_lines_autosomal)
+            return self.heterozygous_lines_autosomal / self.called_lines_autosomal
         elif chrom == "X":
-            return "{0:.2f}".format(self.heterozygous_lines_x / self.called_lines_x)
+            return self.heterozygous_lines_x / self.called_lines_x
         else:
             raise NotImplementedError(f"cannot calculate heterozygosity for chrom {chrom}")
 

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -27,7 +27,7 @@ def genome_reader() -> ReferenceGenome:
 
 
 class TestVCF:
-    def test_header_no_data(self, blocks, genome_reader):
+    def test_header_only(self, genome_reader):
 
         """
         GIVEN a VCF generator
@@ -71,7 +71,6 @@ class TestVCF:
         """
         header_data = {}
         for line in lines:
-            print(line)
             assert line
             assert line[:2] == "##"
             field, data = line[2:].split("=", maxsplit=1)

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -27,11 +27,13 @@ def genome_reader() -> ReferenceGenome:
 
 
 class TestVCF:
-    def test_header(self, genome_reader):
+    def test_header_no_data(self, blocks, genome_reader):
+
         """
         GIVEN a VCF generator
         """
         vcfgenerator = VCFMaker(genome_reader, {})
+
         """
         WHEN generating a header
         """
@@ -42,6 +44,65 @@ class TestVCF:
         for line in lines:
             assert line
             assert line[0] == "#"
+
+    def test_header(self, blocks, genome_reader):
+        """
+        GIVEN an interable of blocks
+        """
+        vcfgenerator = VCFMaker(genome_reader, {})
+
+        """
+        GIVEN a VCF generator
+        """
+        # generate vcf lines and qc info
+        vcf_lines = [line for line in vcfgenerator.generate_lines(blocks)]
+
+        """
+        WHEN generating a header
+        """
+        lines = tuple(
+            (
+                str(i)
+                for i in vcfgenerator.generate_header("2022-03-25 9:20 AM", "GSAMD-24v3-0-EA_20034606_A2", "GRCh38")
+            )
+        )
+        """
+        THEN it should produce valid header output
+        """
+        header_data = {}
+        for line in lines:
+            print(line)
+            assert line
+            assert line[:2] == "##"
+            field, data = line[2:].split("=", maxsplit=1)
+            if field in ("contig", "qc_stats"):
+                data_dict = {}
+                for stat in data[1:-1].split(","):
+                    name, value = stat.split("=")
+                    data_dict[name] = value
+                if field == "contig":
+                    try:
+                        header_data[field].append(data_dict)
+                    except KeyError:
+                        header_data[field] = [
+                            data_dict,
+                        ]
+                else:
+                    header_data[field] = data_dict
+            else:
+                header_data[field] = data
+        assert header_data["fileformat"] == "VCFv4.3"
+        assert "filedate" in header_data  # this is not getting properly formatted
+        assert header_data["source"] == '"GSAMD-24v3-0-EA_20034606_A2, Sano Genetics"'
+        assert header_data["FILTER"] == '<ID=PASS,Description="All filters passed">'
+        assert header_data["FORMAT"] == "<ID=GT,Number=1,Type=String,Description=Genotype>"
+        assert len(header_data["contig"]) == 5
+        for chrom_info in header_data["contig"]:
+            assert int(chrom_info["length"]) == 3000000
+            assert chrom_info["assembly"] == "GRCh38"
+            assert chrom_info["ID"] in ("chr1", "chr2", "chr10", "chrX", "chrY")
+        for stat in header_data["qc_stats"]:
+            assert float(header_data["qc_stats"][stat]) <= 1
 
     def test_data(self, blocks, genome_reader):
         """


### PR DESCRIPTION
Adds a single header line with `##qc_stats=<callrate=0.99,het=0.33,x_het=0.21,y_notnull=0.24>`. These names match what we currently store in the Qcs table, but not the names in the VCF spec. There's a number of additional stats in Qcs that we could add here if we want to keep the QC data consistent (`sex_x`, `sex_y`, `count_raw`, `count_rsid`, `count_notnull`). 

These stats are only calculated for single-sample vcfs. It would be a fairly simple extension to support multi-sample vcfs, but we don't currently have a use case for this

This creates a second copy of all the data in memory because lines need to be sorted before generating the VCF blocks, but qc stats are calculated on simplified blocks. Not sure of a way around this (other than getting fancy about writing to the header block after writing the vcf lines).

I probably need to add some tests here before we merge this.