### PR TITLE
Revert changes to SNP naming

### DIFF
--- a/illumina2vcf/illumina.py
+++ b/illumina2vcf/illumina.py
@@ -5,7 +5,6 @@ from typing import FrozenSet, Generator, Iterable, List, Tuple
 
 # header constants
 SAMPLE_ID = "Sample ID"
-ILMNID = "IlmnID"
 SNP_NAME = "SNP Name"
 CHR = "Chr"
 POSITION = "Position"
@@ -22,7 +21,6 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class IlluminaRow:
     sample_id: str
-    ilmn_id: str
     snp_name: str
     chrom: str
     pos: int
@@ -141,9 +139,6 @@ class IlluminaReader:
             if POSITION not in row:
                 msg = f"{POSITION} missing in row {i}"
                 raise DataError(msg)
-            if ILMNID not in row:
-                msg = f"{ILMNID} missing in row {i}"
-                raise DataError(msg)
             if SNP_NAME not in row:
                 msg = f"{SNP_NAME} missing in row {i}"
                 raise DataError(msg)
@@ -153,7 +148,6 @@ class IlluminaReader:
 
             row_mini = IlluminaRow(
                 row[SAMPLE_ID],
-                row[ILMNID],
                 row[SNP_NAME],
                 row[CHR],
                 int(row[POSITION]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from illumina2vcf.bpm.bpmrecord import COMPLEMENT_MAP
 
 @dataclass
 class ProbeInfo:
-    ilmn_id: str
     name: str
     chrom: str
     pos: int
@@ -62,7 +61,6 @@ class IlluminaBuilder:
             reader = csv.DictReader(infile)
             for row in reader:
                 yield ProbeInfo(
-                    ilmn_id = row["IlmnID"],
                     name=row["Name"],
                     chrom=row["Chr"],
                     pos=int(row["MapInfo"]),
@@ -116,7 +114,6 @@ class IlluminaBuilder:
             return tuple(
                 (
                     "Sample ID",
-                    "IlmnID",
                     "RsID",
                     "GC Score",
                     "SNP Name",
@@ -154,7 +151,6 @@ class IlluminaBuilder:
             return tuple(
                 (
                     "Sample ID",
-                    "IlmnID",
                     "SNP Name",
                     "Sample Name",
                     "Chr",
@@ -176,7 +172,6 @@ class IlluminaBuilder:
                 data = {}
                 data["Sample ID"] = sample
                 data["Sample Index"] = i
-                data["IlmnID"] = probe.ilmn_id
                 data["SNP Name"] = probe.name
                 data["Chr"] = probe.chrom
                 data["Position"] = probe.pos
@@ -185,11 +180,11 @@ class IlluminaBuilder:
                 alleles = (
                     [COMPLEMENT_MAP[probe.a], COMPLEMENT_MAP[probe.b]] if probe.strand == "-" else [probe.a, probe.b]
                 )
-                if probe.ilmn_id in self._genotypes:
-                    allele1 = self._genotypes[probe.ilmn_id][sample][0]
+                if probe.name in self._genotypes:
+                    allele1 = self._genotypes[probe.name][sample][0]
                     assert allele1 in alleles or allele1 == '-'
                     data["Allele1 - Plus"] = allele1
-                    allele2 = self._genotypes[probe.ilmn_id][sample][1]
+                    allele2 = self._genotypes[probe.name][sample][1]
                     assert allele2 in alleles or allele2 == '-'
                     data["Allele2 - Plus"] = allele2
                 else:

--- a/tests/illumina_test.py
+++ b/tests/illumina_test.py
@@ -83,4 +83,4 @@ Total Samples	24"""
             assert len(set(i.chrom for i in block)) == 1
             assert len(set(i.pos for i in block)) == 1
             # each line should have a unique sample and ilmn ids
-            assert len(set((i.sample_id, i.ilmn_id) for i in block)) == len(block)
+            assert len(set((i.sample_id, i.snp_name) for i in block)) == len(block)

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -22,37 +22,41 @@ def blocks() -> Tuple[List[Dict[str, str]], ...]:
 
 @fixture
 def genotypes() -> Dict[str, Dict[str, Tuple]]:
-    genotypes = {'rs76584377-138_Inf2_C_T': {'Sample0': ('C', 'T'),
-                                                 'Sample1': ('C', 'T'),
-                                                 'Sample2': ('C', 'C'),
-                                                 'Sample3': ('C', 'C'),
-                                                 'Sample4': ('C', 'C'),
-                                                 'Sample5': ('C', 'C'),
-                                                 'Sample6': ('C', 'T'),
-                                                 'Sample7': ('C', 'T'),
-                                                 'Sample8': ('T', 'T'),
-                                                },
-                     'rs76584377-138_Inf1_C_T': {'Sample0': ('C', 'T'),
-                                                 'Sample1': ('C', 'T'),
-                                                 'Sample2': ('C', 'C'),
-                                                 'Sample3': ('C', 'C'),
-                                                 'Sample4': ('C', 'C'),
-                                                 'Sample5': ('C', 'T'),
-                                                 'Sample6': ('C', 'T'),
-                                                 'Sample7': ('T', 'T'),
-                                                 'Sample8': ('T', 'T'),
-                                                 },
-                     'rs76584377-138_Inf1_C_G': {'Sample0': ('C', 'C'),
-                                                 'Sample1': ('-', '-'),
-                                                 'Sample2': ('-', '-'),
-                                                 'Sample3': ('C', 'G'),
-                                                 'Sample4': ('G', 'G'),
-                                                 'Sample5': ('C', 'C'),
-                                                 'Sample6': ('-', '-'),
-                                                 'Sample7': ('G', 'G'),
-                                                 'Sample8': ('-', '-'),
-                                                 }
-                    }
+    genotypes = {
+        'rs76584377': { # rs76584377-138_Inf2_C_T
+            'Sample0': ('C', 'T'),
+            'Sample1': ('C', 'T'),
+            'Sample2': ('C', 'C'),
+            'Sample3': ('C', 'C'),
+            'Sample4': ('C', 'C'),
+            'Sample5': ('C', 'C'),
+            'Sample6': ('C', 'T'),
+            'Sample7': ('C', 'T'),
+            'Sample8': ('T', 'T'),
+        },
+        'rs76584377.1': { # rs76584377-138_Inf1_C_T
+            'Sample0': ('C', 'T'),
+            'Sample1': ('C', 'T'),
+            'Sample2': ('C', 'C'),
+            'Sample3': ('C', 'C'),
+            'Sample4': ('C', 'C'),
+            'Sample5': ('C', 'T'),
+            'Sample6': ('C', 'T'),
+            'Sample7': ('T', 'T'),
+            'Sample8': ('T', 'T'),
+        },
+        'rs76584377.2': { # rs76584377-138_Inf1_C_G'
+            'Sample0': ('C', 'C'),
+            'Sample1': ('-', '-'),
+            'Sample2': ('-', '-'),
+            'Sample3': ('C', 'G'),
+            'Sample4': ('G', 'G'),
+            'Sample5': ('C', 'C'),
+            'Sample6': ('-', '-'),
+            'Sample7': ('G', 'G'),
+            'Sample8': ('-', '-'),
+        }
+    }
     return genotypes
 
 @fixture


### PR DESCRIPTION
As part of the changes to combining probes at the same locus, I switched from using the 'snp name' column to identify probes to 'illumina id' with the idea that multiple probes could have the same snp name. This ended up not working anyway, so I had to make snp names unique. It turns out that in production data the illumina id column is not always present, so data processing is failing in production.

This PR reverts to the old behaviour where probes are identified by snp name

Ideally we'd write some new tests to reflect the problem encountered in production to prevent this from happening again in future, but I have neither the time nor the skills to figure that out right now. This should unblock Summit data processing for now at least