### PR TITLE
Fix Docker image build and push for illumina2vcf

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,37 +1,24 @@
-# first build a wheel file
-FROM ubuntu:mantic as buildenv
-
+# ---- build the wheel ----
+FROM python:3.11-slim AS buildenv
 WORKDIR /app
-
-# install Python
-RUN apt-get update \
-  && apt-get install -y python3.11 python3-pip
-
-RUN pip install hatch --break-system-packages
-
-# install the actual code
+RUN pip install --no-cache-dir hatch
+COPY pyproject.toml README.md ./
 COPY illumina2vcf ./illumina2vcf
-COPY pyproject.toml .
-COPY README.md .
-
 RUN hatch build -t wheel
 
-
-# use base image that already has AWS CLI & HTSLIB+SAMTools+VCFTools
-FROM htslib-bcftools-samtools:latest
-
+# ---- runtime (Sano base) ----
+FROM sanogenetics/htslib-bcftools-samtools:latest AS runtime
 WORKDIR /app
-# install Python
+
+# Python for runtime (keep AWS CLI as-is)
 RUN apt-get update \
-  && apt-get install -y python3.11 python3-pip
+  && apt-get install -y --no-install-recommends python3 python3-pip ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
-# install the wheel file built previously
-COPY --from=buildenv /app/dist/illumina2vcf-0.0.1-py3-none-any.whl /app
-RUN pip install /app/illumina2vcf-0.0.1-py3-none-any.whl --break-system-packages \
-  && rm /app/illumina2vcf-0.0.1-py3-none-any.whl
+# Install your wheel
+COPY --from=buildenv /app/dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl --break-system-packages && rm -f /tmp/*.whl
 
-# add the wrapper script
 ENV AWS_CLI_ARGS=
-COPY docker/run.sh .
-
-CMD ["sh", "run.sh"]
+COPY docker/run.sh /app/run.sh
+CMD ["sh", "/app/run.sh"]


### PR DESCRIPTION
## summary

- replaced deprecated `ubuntu:mantic` build stage with `python:3.11-slim` to ensure reliable Python wheel builds
- updated runtime stage to use s`anogenetics/htslib-bcftools-samtools:latest` explicitly (previously referenced a non-existent library/`htslib-bcftools-samtools`)
- ensured Python (python3, pip) is installed in the runtime container so the illumina2vcf wheel can run
- handled AWS CLI: skipped apt install (not available in Ubuntu 24.04) since AWS CLI v2 already exists in the base image.
- final image now builds cleanly and contains all required runtime dependencies:
- Python 3.x
- AWS CLI v2
- htslib, bcftools, samtools

the docker image can now be rebuilt and pushed to dockerhub as sanogenetics/illumina2vcf:latest and version-tagged