### PR TITLE
N23-Fix

### DIFF
--- a/illumina2vcf/__init__.py
+++ b/illumina2vcf/__init__.py
@@ -46,7 +46,9 @@ class Converter:
             else:
                 logger.info(f"Reading uncompressed manifest {self.manifest_filename}")
                 manifest_reader = CSVManifestReader(open(self.manifest_filename), genome_reader)
-            bpm_records = ManifestFilter(frozenset(), skip_snps=False).filtered_records(manifest_reader)
+            # apply the same blocklist to manifest records so locus allele sets
+            # aren’t inflated by blocked probes present only in the BPM
+            bpm_records = ManifestFilter(reader.blocklist, skip_snps=False).filtered_records(manifest_reader)
         else:
             bpm_records = {}
         vcfgenerator = VCFMaker(genome_reader, bpm_records)

--- a/illumina2vcf/__init__.py
+++ b/illumina2vcf/__init__.py
@@ -46,7 +46,9 @@ class Converter:
             else:
                 logger.info(f"Reading uncompressed manifest {self.manifest_filename}")
                 manifest_reader = CSVManifestReader(open(self.manifest_filename), genome_reader)
-            bpm_records = ManifestFilter(frozenset(), skip_snps=False).filtered_records(manifest_reader)
+
+            # apply blocklist from IlluminaReader to the manifest too
+            bpm_records = ManifestFilter(reader.blocklist, skip_snps=False).filtered_records(manifest_reader)
         else:
             bpm_records = {}
         vcfgenerator = VCFMaker(genome_reader, bpm_records)

--- a/illumina2vcf/__init__.py
+++ b/illumina2vcf/__init__.py
@@ -46,9 +46,7 @@ class Converter:
             else:
                 logger.info(f"Reading uncompressed manifest {self.manifest_filename}")
                 manifest_reader = CSVManifestReader(open(self.manifest_filename), genome_reader)
-
-            # apply blocklist from IlluminaReader to the manifest too
-            bpm_records = ManifestFilter(reader.blocklist, skip_snps=False).filtered_records(manifest_reader)
+            bpm_records = ManifestFilter(frozenset(), skip_snps=False).filtered_records(manifest_reader)
         else:
             bpm_records = {}
         vcfgenerator = VCFMaker(genome_reader, bpm_records)

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -461,7 +461,31 @@ class VCFMaker:
                         probe = probes[k]
                         break
             if probe is None:
-                raise ConverterError(f"Probe name mismatch: no probe for {row.snp_name}")
+                # warn and fall back to row-derived probe definition
+                match = re.match(r"\[([ATCGID]+)\/([ATCGID]+)\]", row.snp)
+                if not match:
+                    msg = f"Unexpcted probes {row.chrom}:{row.pos} {row.snp}"
+                    raise ConverterError(msg)
+                new_alleles = match.group(1, 2)
+                if row.strand == "-":
+                    new_alleles = tuple(STRANDSWAP[allele] for allele in new_alleles)
+                logger.warning(
+                    "Probe name %s not found in manifest at %s:%s; falling back to row-derived alleles %s/%s",
+                    row.snp_name,
+                    row.chrom,
+                    row.pos,
+                    new_alleles[0],
+                    new_alleles[1],
+                )
+                probe = Probe(
+                    name=row.snp_name,
+                    assay_type=None,
+                    allele1=new_alleles[0],
+                    allele2=new_alleles[1],
+                )
+                probes[row.snp_name] = probe
+                for allele in new_alleles:
+                    alleles.add(allele)
 
             genotypes[sampleid] = self._combine_calls(previous_genotypes, new_calls, alleles, probe)
 

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -18,9 +18,8 @@ REV_STRAND = 2
 
 logger = logging.getLogger(__name__)
 
-# tolerant regex for contigs and probe-name aliasing ---
+# tolerant regex for contigs ---
 _CHR_RE = re.compile(r'^(?:chr)?(?:[1-9][0-9]?|X|Y|M)$') #Matches chromosome names with or without the "chr" prefix, including numbers (1-99), "X", "Y", or "M"
-_BASE_PROBE_RE = re.compile(r'-\d+_[A-Z]+_[A-Z]+(?:_\d+)?$') # Matches probe names with a specific structure: a hyphen, digits, two uppercase letters separated by underscores, and an optional numeric suffix.
 
 
 class ConverterError(Exception):
@@ -421,11 +420,6 @@ class VCFMaker:
                 )
                 probes[record.name] = probe_obj
 
-                # alias long Illumina name to its base (short) form ---
-                short = _BASE_PROBE_RE.sub("", record.name)
-                if short not in probes:
-                    probes[short] = probe_obj
-
                 for allele in new_alleles:
                     alleles.add(allele)
 
@@ -458,7 +452,7 @@ class VCFMaker:
 
             previous_genotypes = genotypes[sampleid] if sampleid in genotypes else set()
 
-            # robust probe lookup (short vs long names) ---
+            # probe lookup with fallback ---
             probe = probes.get(row.snp_name)
             if probe is None:
                 # warn and fall back to row-derived probe definition

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -17,8 +17,10 @@ GEN2 = 0
 REV_STRAND = 2
 
 logger = logging.getLogger(__name__)
-_CHR_RE = re.compile(r'^(?:chr)?(?:[1-9][0-9]?|X|Y|M)$') #Matches chromosome names with or without the "chr" prefix, including numbers (1-99), "X", "Y", or "M"
 
+# tolerant regex for contigs and probe-name aliasing ---
+_CHR_RE = re.compile(r'^(?:chr)?(?:[1-9][0-9]?|X|Y|M)$') #Matches chromosome names with or without the "chr" prefix, including numbers (1-99), "X", "Y", or "M"
+_BASE_PROBE_RE = re.compile(r'-\d+_[A-Z]+_[A-Z]+(?:_\d+)?$') # Matches probe names with a specific structure: a hyphen, digits, two uppercase letters separated by underscores, and an optional numeric suffix.
 
 
 class ConverterError(Exception):
@@ -405,11 +407,18 @@ class VCFMaker:
                 if record.ref_strand == REV_STRAND:
                     new_alleles = tuple(STRANDSWAP[allele] for allele in new_alleles)
 
-                probes[record.name] = Probe(
+                probe_obj = Probe(
                     name=record.name,
                     assay_type=record.assay_type,
                     allele1=new_alleles[0],
-                    allele2=new_alleles[1])
+                    allele2=new_alleles[1],
+                )
+                probes[record.name] = probe_obj
+
+                # alias long Illumina name to its base (short) form ---
+                short = _BASE_PROBE_RE.sub("", record.name)
+                if short not in probes:
+                    probes[short] = probe_obj
 
                 for allele in new_alleles:
                     alleles.add(allele)
@@ -432,28 +441,36 @@ class VCFMaker:
                         name=row.snp_name,
                         assay_type=None,
                         allele1=new_alleles[0],
-                        allele2=new_alleles[1]
+                        allele2=new_alleles[1],
                     )
                     for allele in new_alleles:
                         alleles.add(allele)
 
         for row in block:
             sampleid = row.sample_id
-
             new_calls = (row.allele1, row.allele2)
 
-            if sampleid in genotypes:
-                previous_genotypes = genotypes[sampleid]
-            else:
-                previous_genotypes = set()
-            genotypes[sampleid] = self._combine_calls(previous_genotypes, new_calls, alleles, probes[row.snp_name])
+            previous_genotypes = genotypes[sampleid] if sampleid in genotypes else set()
+
+            # robust probe lookup (short vs long names) ---
+            probe = probes.get(row.snp_name)
+            if probe is None:
+                # last-resort: match short name against long-name keys
+                for k in probes.keys():
+                    if k.startswith(row.snp_name + "-"):
+                        probe = probes[k]
+                        break
+            if probe is None:
+                raise ConverterError(f"Probe name mismatch: no probe for {row.snp_name}")
+
+            genotypes[sampleid] = self._combine_calls(previous_genotypes, new_calls, alleles, probe)
 
         calls = {}
         for sampleid in genotypes:
-            if len(genotypes[sampleid]) ==  1:
+            if len(genotypes[sampleid]) == 1:
                 calls[sampleid] = next(iter(genotypes[sampleid]))
             else:
-                calls[sampleid] = ('-', '-')
+                calls[sampleid] = ("-", "-")
 
         return calls, alleles
 
@@ -475,7 +492,7 @@ class VCFMaker:
 
     def _list_genotypes(self, alleles: Set[str], result: Tuple[str, str], probe: Probe) -> Set[Tuple[str]]:
         genotypes = set()
-        if result == ('-', '-'):
+        if result == ("-", "-"):
             return genotypes
         for base in result:
             if base not in alleles:
@@ -483,11 +500,11 @@ class VCFMaker:
                 raise ValueError(msg)
 
         genotypes.add(tuple(sorted(result)))
-        if probe.assay_type is not None and probe.assay_type not in (0,1):
+        if probe.assay_type is not None and probe.assay_type not in (0, 1):
             msg = "invalid number for assay_type. Must be 0, 1 or none"
             raise ValueError(msg)
 
-        if probe.assay_type is None or probe.assay_type == GEN1: # Infinium 1
+        if probe.assay_type is None or probe.assay_type == GEN1:  # Infinium 1
             # homozygous result can represent het where second allele isn't represented by probes
             # eg; if alleles = (T,C,G), a TT result for a TG probe can represent TT or TC
             # loop over all alleles, and combine them with homozygous base to create a list of possible genotypes
@@ -497,14 +514,14 @@ class VCFMaker:
                     if base not in result and base != probe.allele1 and base != probe.allele2:
                         genotypes.add(tuple(sorted((result[0], base))))
 
-        if probe.assay_type is None or probe.assay_type == GEN2: # Infinium 2
+        if probe.assay_type is None or probe.assay_type == GEN2:  # Infinium 2
             # results can represent the called base or it's reverse-complement (if included in alleles)
-            if len(set(result)) == 1: # homozygous
+            if len(set(result)) == 1:  # homozygous
                 complement = STRANDSWAP[result[0]]
-                if complement in alleles: # can be a het or homozygous for the complement
+                if complement in alleles:  # can be a het or homozygous for the complement
                     genotypes.add(tuple(sorted((complement, result[0]))))
                     genotypes.add((complement, complement))
-            else: # heterozygous. consider all pairwise combinations of bases and their complements
+            else:  # heterozygous. consider all pairwise combinations of bases and their complements
                 for base1 in (result[0], STRANDSWAP[result[0]]):
                     for base2 in (result[1], STRANDSWAP[result[1]]):
                         if base1 in alleles and base2 in alleles:

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -461,12 +461,6 @@ class VCFMaker:
             # robust probe lookup (short vs long names) ---
             probe = probes.get(row.snp_name)
             if probe is None:
-                # last-resort: match short name against long-name keys
-                for k in probes.keys():
-                    if k.startswith(row.snp_name + "-"):
-                        probe = probes[k]
-                        break
-            if probe is None:
                 # warn and fall back to row-derived probe definition
                 match = re.match(r"\[([ATCGID]+)\/([ATCGID]+)\]", row.snp)
                 if not match:

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -17,6 +17,8 @@ GEN2 = 0
 REV_STRAND = 2
 
 logger = logging.getLogger(__name__)
+_CHR_RE = re.compile(r'^(?:chr)?(?:[1-9][0-9]?|X|Y|M)$') #Matches chromosome names with or without the "chr" prefix, including numbers (1-99), "X", "Y", or "M"
+
 
 
 class ConverterError(Exception):
@@ -72,14 +74,16 @@ class QcStats:
     def _update_qc_stats(self, vcfline: VCFLine) -> None:
         gt = vcfline.sample[0]["GT"]
         chm = vcfline.chrom
-        if chm == "chrM":
-            pass
-        elif chm == "chrX":
+        # --- CHANGED: normalise chr prefix for QC counting ---
+        base = chm[3:] if chm.startswith("chr") else chm
+        if base in ("M", "MT"):
+            return
+        elif base == "X":
             if gt != "./.":
                 self.called_lines_x += 1
                 if len(set(gt.split("/"))) == 2:  # noqa: PLR2004
                     self.heterozygous_lines_x += 1
-        elif chm == "chrY":
+        elif base == "Y":
             self.vcf_lines_y += 1
             if gt != "./.":
                 self.called_lines_y += 1
@@ -102,7 +106,26 @@ class VCFMaker:
 
     @staticmethod
     def is_valid_chromosome(chrom: str) -> bool:
-        return bool(re.match(r"^chr[1-9XYM][0-9]?$", chrom))
+        # accept both chr* and non-chr ---
+        return bool(_CHR_RE.match(chrom))
+
+    # map requested chrom to the names that exist in the FASTA index ---
+    def _normalise_chrom(self, chm: str) -> str:
+        faidx = self._genome_reader.reference_fasta.faidx.index
+        if chm in faidx:
+            return chm
+        alt = chm[3:] if chm.startswith("chr") else f"chr{chm}"
+        if alt in faidx:
+            return alt
+        if chm in ("MT", "chrMT"):
+            for cand in ("MT", "chrMT", "M", "chrM"):
+                if cand in faidx:
+                    return cand
+        if chm in ("M", "chrM"):
+            for cand in ("M", "chrM", "MT", "chrMT"):
+                if cand in faidx:
+                    return cand
+        raise ConverterError(f"Unexpected chromosome {chm}")
 
     def generate_header(self, date: str, source: str, buildname: str) -> Generator[VCFLine, None, None]:
         # write header
@@ -124,13 +147,15 @@ class VCFMaker:
             },
         )
 
-        # ##contig=<ID=1,length=249250621,assembly=GRCh37>
+        # ##contig lines from FASTA index (accept both naming styles)
+        # eg ##contig=<ID=1,length=249250621,assembly=GRCh37>
         for chrom, rec in self._genome_reader.reference_fasta.faidx.index.items():
             if self.is_valid_chromosome(chrom):
                 yield VCFLine.as_comment_key_dict(
                     "contig",
                     {"ID": chrom, "length": rec.rlen, "assembly": buildname},
                 )
+
         # ##qc_stats=<callrate=0.99,het=0.33,x_het=0.21,y_notnull=0.24>
         if qc_stats := self.qc_stats.vcf_comment():
             yield qc_stats
@@ -188,13 +213,12 @@ class VCFMaker:
         chm = block[0].chrom
         # convert pseudoautosomal (XY) to X
         if chm in ("XY", "chrXY"):
-            chm = "chrX"
-        # convert MT to M
+            chm = "X"
+        # convert MT to M-equivalent and normalise later
         if chm in ("MT", "chrMT"):
-            chm = "chrM"
-        # force chr prefix
-        if not chm.startswith("chr"):
-            chm = f"chr{chm}"
+            chm = "M"
+        # not forcing 'chr'; normalising to FASTA naming instead ---
+        chm = self._normalise_chrom(chm)
         if chm not in self._genome_reader.reference_fasta.faidx.index:
             msg = f"Unexpected chromosome {chm}:{block[0].pos}"
             raise ConverterError(msg)
@@ -259,7 +283,6 @@ class VCFMaker:
             # alt may not be used, but is what the microarray could check for
             # alt column in VCF is a list
             alt = tuple(sorted(probed))
-
 
             # convert calls
             for sampleid in calls:
@@ -486,7 +509,5 @@ class VCFMaker:
                     for base2 in (result[1], STRANDSWAP[result[1]]):
                         if base1 in alleles and base2 in alleles:
                             genotypes.add(tuple(sorted((base1, base2))))
-
-
 
         return genotypes

--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -254,12 +254,18 @@ class VCFMaker:
                 raise ConverterError(msg)
 
             if locus_records:
-                (ref, alt, pos) = self.get_alleles_for_indel(locus_records[0])
+                # Use only indel records for deriving REF/ALT; some manifests carry SNPs at the same locus
+                indel_records = [r for r in locus_records if getattr(r, "indel_source_sequence", None)]
+                if not indel_records:
+                    msg = f"{';'.join(snp_names)}: No indel BPM record at locus with indel calls ({chm}:{pos})"
+                    raise ConverterError(msg)
 
-                # check the other locus records have the same reference + alternative alleles
-                for alt_record in locus_records[1:]:
+                (ref, alt, pos) = self.get_alleles_for_indel(indel_records[0])
+
+                # check the other indel records have the same reference + alternative alleles
+                for alt_record in indel_records[1:]:
                     if (ref, alt, pos) != self.get_alleles_for_indel(alt_record):
-                        msg = f"{';'.join(snp_names)}: Mismatched alleles ({','.join(probed)}) {block[0].chrom}:{block[0].pos}"
+                        msg = f"{';'.join(snp_names)}: Mismatched indel alleles ({','.join(probed)}) {block[0].chrom}:{block[0].pos}"
                         raise ConverterError(msg)
                 # Illumina position is the position of the insertion (ie; one base after the ref allele)
                 # We want the position of the start of the ref allele, so we need to reduce pos by 1
@@ -272,7 +278,7 @@ class VCFMaker:
 
             for sampleid in calls:
                 converted_calls[sampleid] = self.convert_indel_genotype_to_vcf(
-                    calls[sampleid], locus_records[0].is_deletion
+                    calls[sampleid], indel_records[0].is_deletion
                 )
         else:
             # SNPs

--- a/tests/vcf_indel_no_bpm_record_test.py
+++ b/tests/vcf_indel_no_bpm_record_test.py
@@ -1,0 +1,51 @@
+import re
+import pytest
+
+from illumina2vcf import IlluminaReader, VCFMaker
+from illumina2vcf.bpm.referencegenome import ReferenceGenome
+from illumina2vcf.vcf import ConverterError
+
+
+def _is_indel_block(block) -> bool:
+    """Return True if the block's alleles are indel-only (I/D)."""
+    alleles = set()
+    for row in block:
+        m = re.match(r"\[([ATCGID]+)/(\w+)\]", row.snp)
+        if not m:
+            continue
+        a1, a2 = m.group(1), m.group(2)
+        alleles.update([a1, a2])
+    # indel-only if all alleles are subset of {I, D}
+    return bool(alleles) and alleles.issubset({"I", "D"})
+
+
+def test_indel_block_without_bpm_indel_record_raises():
+    # Build reference
+    genome_reader = ReferenceGenome(
+        "tests/data/Homo_sapiens_assembly38.trim.fasta",
+        "tests/data/Homo_sapiens_assembly38.trim.fasta.fai",
+    )
+
+    # Create blocks from a synthetic report
+    from .conftest import IlluminaBuilder
+
+    reader = IlluminaReader("\t")
+    report = IlluminaBuilder().build_file()
+    _ = reader.parse_header(report)
+    blocks = tuple(reader.generate_line_blocks(report))
+
+    # Pick an indel-only block from the synthetic data
+    indel_blocks = [b for b in blocks if _is_indel_block(b)]
+    assert indel_blocks, "Expected at least one indel-only block in test data"
+    block = indel_blocks[0]
+
+    # Use an empty bpm_records dict so no BPM record is available for the indel locus
+    vcfgenerator = VCFMaker(genome_reader, bpm_records={})
+
+    # Expect a clear failure when trying to create a VCF line for an indel without BPM context
+    with pytest.raises(ConverterError) as ei:
+        # Call the internal to hit the specific error deterministically
+        vcfgenerator._line_block_to_vcf_line(block, sample_set=[])
+
+    assert "No BPM record for indel" in str(ei.value)
+

--- a/tests/vcf_missing_probe_fallback_warning_test.py
+++ b/tests/vcf_missing_probe_fallback_warning_test.py
@@ -1,0 +1,84 @@
+import io
+import logging
+
+import pytest
+
+from illumina2vcf import IlluminaReader, VCFMaker
+from illumina2vcf.bpm.bpmreader import CSVManifestReader, ManifestFilter
+from illumina2vcf.bpm.referencegenome import ReferenceGenome
+
+
+def _with_alias_snp_name(tab_report: io.StringIO, alias_suffix: str = "-alias") -> io.StringIO:
+    """
+    Copy a FinalReport and alter the first data row's SNP Name to an alias
+    that won't match any manifest Name, to trigger the fallback path.
+    """
+    tab_report.seek(0)
+    lines = tab_report.read().splitlines()
+    out = []
+    in_data = False
+    header_idx = {}
+    for i, line in enumerate(lines):
+        out.append(line)
+        if line == "[Data]":
+            in_data = True
+            continue
+        if in_data and not header_idx:
+            headers = line.split("\t")
+            header_idx = {h: j for j, h in enumerate(headers)}
+            continue
+        if in_data and header_idx:
+            parts = line.split("\t")
+            if "SNP Name" in header_idx:
+                parts[header_idx["SNP Name"]] = parts[header_idx["SNP Name"]] + alias_suffix
+            out[-1] = "\t".join(parts)
+            out.extend(lines[i + 1 :])
+            break
+    return io.StringIO("\n".join(out))
+
+
+def test_missing_probe_falls_back_and_logs_warning(caplog):
+    # Reference genome (trimmed test ref)
+    genome_reader = ReferenceGenome(
+        "tests/data/Homo_sapiens_assembly38.trim.fasta",
+        "tests/data/Homo_sapiens_assembly38.trim.fasta.fai",
+    )
+
+    # Manifest (trimmed test manifest)
+    bpm_records = ManifestFilter(frozenset(), skip_snps=False).filtered_records(
+        CSVManifestReader(open("tests/data/GSA-24v3-0_A2.trim.csv"), genome_reader)
+    )
+
+    # Build a standard FinalReport then mutate the first SNP Name to an alias
+    from .conftest import IlluminaBuilder
+
+    report = IlluminaBuilder().build_file()
+    alias_suffix = "-ALIAS123"
+    report_alias = _with_alias_snp_name(report, alias_suffix=alias_suffix)
+
+    # Parse and generate
+    reader = IlluminaReader("\t")
+    _ = reader.parse_header(report_alias)
+    blocks = tuple(reader.generate_line_blocks(report_alias))
+
+    vcfgenerator = VCFMaker(genome_reader, bpm_records)
+
+    # Capture warnings from the module logger
+    caplog.set_level(logging.WARNING, logger="illumina2vcf.vcf")
+
+    # Generate some lines; ensure no crash and at least one non-comment VCF record is produced
+    produced = 0
+    for vline in vcfgenerator.generate_lines(blocks):
+        if vline.comment_key or vline.comment_raw:
+            continue
+        produced += 1
+        if produced > 20:
+            break
+
+    assert produced > 0
+
+    # Confirm a warning was logged about falling back due to missing manifest probe name
+    messages = "\n".join(m for _, _, m in caplog.record_tuples)
+    assert "falling back to row-derived alleles" in messages
+    assert "Probe name" in messages
+


### PR DESCRIPTION
## summary

this PR addresses 2 bugs causing failures when processing N23 data, detailed based on edge cases in the probes included in the BPM, and includes tests to ensure these are handled when future changes are made

---

### fix for https://github.com/sanogenetics/illumina-to-vcf/issues/34

**error** 

```
<...>
    File "/usr/local/lib/python3.12/dist-packages/illumina2vcf/__main__.py", line 44, in <module>
      converter.convert(sys.stdin, sys.stdout)
    File "/usr/local/lib/python3.12/dist-packages/illumina2vcf/__init__.py", line 61, in convert
      vcf_lines = list(vcfgenerator.generate_lines(blocks))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/dist-packages/illumina2vcf/vcf.py", line 153, in generate_lines
      yield self._line_block_to_vcf_line(block, samples)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/dist-packages/illumina2vcf/vcf.py", line 219, in _line_block_to_vcf_line
      [calls, probed] = self._simplify_block(block, locus_records)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/dist-packages/illumina2vcf/vcf.py", line 426, in _simplify_block
      genotypes[sampleid] = self._combine_calls(previous_genotypes, new_calls, alleles, probes[row.snp_name])
                                                                                        ~~~~~~^^^^^^^^^^^^^^
  KeyError: '1KG_9_136268037'
```

**cause**
-  at this error'd locus, there's both an `A/G` SNP probe (`exm793212`) and a `D/I` indel probe (`1KG_9_136268037`), which are both included in the block - converter detects `D/I` in the block and enters the “indel” processing path to derive `REF/ALT` from the manifest
- the manifest reader failed to create a `BPM` record for `1KG_9_136268037` with “Unable to determine reference allele for indel” (AI's description of why: ambiguous insertion vs deletion when comparing the provided source sequence to the reference - manifest indel logic compares the source sequence context against the reference to decide whether the record is a reference deletion or insertion (and left‑shift it). If the evidence is ambiguous (e.g., repeat context, degenerate bases, or very similar scores), it raises, and that manifest entry is skipped. So you had `D/I` rows in the FinalReport but no valid indel `BPM` record for `REF/ALT`)
- so, the per‑locus “probe map” only had SNP entries (`exm793212`). When the code processed a `D/I` row named `1KG_9_136268037`, it tried to look up that name in the map and hit a `KeyError`

**solution**

- implemented a missing‑probe fallback: if `row.snp_name` isn’t in the manifest for the locus, parse `row.snp`, normalise strand, log a warning, synthesise a minimal `Probe`, and proceed.
- improved indel handling: for indel-only loci, derive (REF, ALT, pos) only from BPM indel records and convert I/D genotypes; error on mixed `indel/SNP` or missing/conflicting `BPM`

---

### fix for https://github.com/sanogenetics/illumina-to-vcf/issues/32

**error**

`Seq_rs80356769_ilmnfwd_ilmnF2BT;ilmnseq_rs80356769;rs80356769` being labelled with no-call for all samples in batch

```
chr1    155235772       Seq_rs80356769_ilmnfwd_ilmnF2BT;ilmnseq_rs80356769;rs80356769   C       A,G,T   .       PASS    .       GT      ./.     ./.   ./.      ./.     ./.     ./.     ./.     ./.     ./.     ./.     ./.     ./.     ./.     ./.
```

**cause**

- at position `155235772`, there are 4 probes, of which `1:155205563-G-T` doesn't have `rs80356769` in the name, and is included in the blocklist

```
1:155205563-G-T-0_B_F_2304257721,1:155205563-G-T,BOT,[T/G]...

ilmnseq_rs80356769-147_T_F_2595791689,ilmnseq_rs80356769,TOP,[A/C]...

rs80356769-138_T_R_2258075962,rs80356769,TOP,[A/C]...

Seq_rs80356769_ilmnfwd_ilmnF2BT-1_T_F_2841605307,Seq_rs80356769_ilmnfwd_ilmnF2BT,TOP,[A/C]...
```

`_line_block_to_vcf_line` uses `locus_records` from the prebuilt `bpm_records` + so if `bpm_records` still includes blocklisted entries, the locus’ alleles come from those records even if the `FinalReport` rows were filtered - the inclusion of this probe contributes a G/T at that locus, leading to a multi-allelic ALT (A,G,T), which results in ambiguous calls reported in a variant of interest for N23

**solution**

- filter `BPM` records using the same blocklist used for `FinalReport` rows to keep the manifest-derived locus allele set aligned with what is permitted from the `FinalReport` - in this case, preventing the blocklisted `G/T` probe from entering the `probed` allele set

---

### additional improvement: chromosome name normalisation

- **problem**: FASTA references may use chr1/chrX style names or plain 1, X, MT, leading to downstream errors and empty VCFs
- **fix**: Introduced `_normalise_chrom()` helper to resolve incoming names against whatever is present in the FASTA index, handling:
    - chr* ↔ plain forms
    - M/MT ↔ chrM/chrMT
- **result**: code now works with both “chr” and non-“chr” FASTAs