### PR TITLE
Bio 150 - no calls have the FILTER field set to FAIL in the vcf

### DIFF
--- a/illumina2vcf/vcf.py
+++ b/illumina2vcf/vcf.py
@@ -137,6 +137,9 @@ class VCFMaker:
         # ##FILTER=<ID=PASS,Description="All filters passed">
         yield VCFLine.as_comment_key_dict("FILTER", {"ID": "PASS", "Description": '"All filters passed"'})
 
+        # ##FILTER=<ID=FAIL,Description="All samples missing genotype calls">
+        yield VCFLine.as_comment_key_dict("FILTER", {"ID": "FAIL", "Description": '"All samples missing genotype call"'})
+
         # ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
         yield VCFLine.as_comment_key_dict(
             "FORMAT",
@@ -321,8 +324,9 @@ class VCFMaker:
         # always need to have all samples on all rows
         # even if that samples has been filtered out e.g. conflicting probes
         samples = [{"GT": converted_calls.get(sampleid, "./.")} for sampleid in sample_set]
-
-        vcfline = VCFLine("", "", "", {}, chm, pos, snp_names, ref, alt, ".", ["PASS"], {}, samples)
+        all_samples_missing_genotypes = all(sample["GT"] == "./." for sample in samples)
+        filter_value = ["FAIL"] if all_samples_missing_genotypes else ["PASS"]
+        vcfline = VCFLine("", "", "", {}, chm, pos, snp_names, ref, alt, ".", filter_value, {}, samples)
 
         # update qc totals if single sample
         if len(samples) == 1:

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -155,7 +155,7 @@ class TestVCF:
             assert line
             assert line[:2] == "##"
             field, data = line[2:].split("=", maxsplit=1)
-            if field in ("contig", "qc_stats"):
+            if field in ("contig", "qc_stats","FILTER"):
                 data_dict = {}
                 for stat in data[1:-1].split(","):
                     name, value = stat.split("=")
@@ -167,6 +167,11 @@ class TestVCF:
                         header_data[field] = [
                             data_dict,
                         ]
+                elif field == "FILTER":
+                    try:
+                        header_data[field].append(data)
+                    except KeyError:
+                        header_data[field] = [data]
                 else:
                     header_data[field] = data_dict
             else:
@@ -174,7 +179,9 @@ class TestVCF:
         assert header_data["fileformat"] == "VCFv4.3"
         assert "filedate" in header_data  # this is not getting properly formatted
         assert header_data["source"] == '"GSAMD-24v3-0-EA_20034606_A2, Sano Genetics"'
-        assert header_data["FILTER"] == '<ID=PASS,Description="All filters passed">'
+        #assert header_data["FILTER"] == '<ID=PASS,Description="All filters passed">'
+        assert '<ID=PASS,Description="All filters passed">' in header_data["FILTER"]
+        assert '<ID=FAIL,Description="All samples missing genotype call">' in header_data["FILTER"]
         assert header_data["FORMAT"] == "<ID=GT,Number=1,Type=String,Description=Genotype>"
         assert len(header_data["contig"]) == 5
         for chrom_info in header_data["contig"]:
@@ -394,3 +401,47 @@ class TestVCF:
                     else:
                         genotype = ('-', '-')
                     assert (sample, genotype) == (sample, results[sample][0])
+    def test_filterstatus_for_all_samples_with_missing_genotypes(self, blocks, genome_reader, monkeypatch):
+        """
+            GIVEN a block where no genotypes are produced
+            THEN FILTER should be FAIL
+        """
+        vcfgenerator = VCFMaker(genome_reader, {})
+
+        # Force _simplify_block to return no calls
+        def fake_simplify_block(block, locus_records):
+            return {block[0].sample_id: ("-", "-")}, {"T","C"}  # conflicting genotype calls returns as no calls, probed contains ref
+
+        monkeypatch.setattr(vcfgenerator, "_simplify_block", fake_simplify_block)
+
+        # Use first real block
+        block = blocks[0]
+        sample_set = [row.sample_id for row in block]
+
+        vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
+        print(vcfline)
+        assert vcfline._filter== ("FAIL",)
+        assert all(s["GT"] == "./." for s in vcfline.sample)
+
+    def test_filterstatus__for_some_samples_with_missinggenotypes(self, blocks, genome_reader, monkeypatch):
+        """
+            GIVEN a block where at least one genotype is produced
+            THEN FILTER should be PASS
+        """
+        vcfgenerator = VCFMaker(genome_reader, {})
+
+        # Return one called genotype
+        def fake_simplify_block(block, locus_records):
+            return {block[0].sample_id: ("C", "C")}, {"T","C"}
+
+        monkeypatch.setattr(vcfgenerator, "_simplify_block", fake_simplify_block)
+
+        block = blocks[0]
+        sample_set = [row.sample_id for row in block]
+
+        vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
+        print(vcfline)
+        assert vcfline._filter == ("PASS",)
+        assert any(s["GT"] != "./." for s in vcfline.sample)
+
+    

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -450,18 +450,19 @@ class TestVCF:
                 MULTI SAMPLEs - at least one called genotype - FILTER should be PASS
         """
         vcfgenerator = VCFMaker(genome_reader, {})
-
+        
         # Return one called genotype
+        
         def fake_simplify_block(block, locus_records):
-            return {block[0].sample_id: ("C", "C")}, {"T","C"}
+            return {'sample1': ("C", "C"), 'sample2': ("-", "-")}, {"T", "C"}
+            
 
         monkeypatch.setattr(vcfgenerator, "_simplify_block", fake_simplify_block)
 
         block = blocks[0]
-        sample_set = [row.sample_id for row in block]
 
+        sample_set = [row.sample_id for row in block]
         vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
-        #print(vcfline)
 
         assert vcfline._filter == ("PASS",)
         assert any(s["GT"] != "./." for s in vcfline.sample)

--- a/tests/vcf_test.py
+++ b/tests/vcf_test.py
@@ -401,32 +401,53 @@ class TestVCF:
                     else:
                         genotype = ('-', '-')
                     assert (sample, genotype) == (sample, results[sample][0])
-    def test_filterstatus_for_all_samples_with_missing_genotypes(self, blocks, genome_reader, monkeypatch):
+    def test_filterstatus_for_single_sample_with_nocall(self, blocks, genome_reader, monkeypatch):
         """
-            GIVEN a block where no genotypes are produced
-            THEN FILTER should be FAIL
+            # SINGLE SAMPLE - with no genotype call - FILTER should be FAIL
+        
         """
         vcfgenerator = VCFMaker(genome_reader, {})
 
         # Force _simplify_block to return no calls
         def fake_simplify_block(block, locus_records):
-            return {block[0].sample_id: ("-", "-")}, {"T","C"}  # conflicting genotype calls returns as no calls, probed contains ref
+            return {block[0].sample_id: ("-", "-")}, {"T","C"}  
 
         monkeypatch.setattr(vcfgenerator, "_simplify_block", fake_simplify_block)
 
-        # Use first real block
-        block = blocks[0]
+
+        block = blocks[0][:1]  # force single sample
         sample_set = [row.sample_id for row in block]
 
         vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
-        print(vcfline)
+
+
         assert vcfline._filter== ("FAIL",)
         assert all(s["GT"] == "./." for s in vcfline.sample)
 
-    def test_filterstatus__for_some_samples_with_missinggenotypes(self, blocks, genome_reader, monkeypatch):
+    def test_filterstatus_for_single_sample_with_calledgenotype(self, blocks, genome_reader, monkeypatch):
         """
-            GIVEN a block where at least one genotype is produced
-            THEN FILTER should be PASS
+            SINGLE SAMPLE - with genotype call - FILTER should be PASS
+        """
+        vcfgenerator = VCFMaker(genome_reader, {})
+
+        # Return one called genotype
+        def fake_simplify_block(block, locus_records):
+            return {block[0].sample_id: ("C", "C")}, {"T","C"}
+
+        monkeypatch.setattr(vcfgenerator, "_simplify_block", fake_simplify_block)
+
+        block = blocks[0][:1]  # force single sample
+        sample_set = [row.sample_id for row in block]
+
+        vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
+        #print(vcfline)
+
+        assert vcfline._filter == ("PASS",)
+        assert any(s["GT"] != "./." for s in vcfline.sample)
+
+    def test_filterstatus_for_multisample_with_calledgenotype(self, blocks, genome_reader, monkeypatch):
+        """
+                MULTI SAMPLEs - at least one called genotype - FILTER should be PASS
         """
         vcfgenerator = VCFMaker(genome_reader, {})
 
@@ -440,8 +461,31 @@ class TestVCF:
         sample_set = [row.sample_id for row in block]
 
         vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
-        print(vcfline)
+        #print(vcfline)
+
         assert vcfline._filter == ("PASS",)
         assert any(s["GT"] != "./." for s in vcfline.sample)
 
-    
+    def test_filterstatus_for_multisample_with_nocalls(self, blocks, genome_reader, monkeypatch):
+        """
+            # MULTI SAMPLE - all samples with no call - FILTER should be FAIL
+        
+        """
+        vcfgenerator = VCFMaker(genome_reader, {})
+
+        # Force _simplify_block to return no calls
+        def fake_simplify_block(block, locus_records):
+            return {row.sample_id: ("-", "-") for row in block}, {"T", "C"}
+
+
+        monkeypatch.setattr(vcfgenerator, "_simplify_block", fake_simplify_block)
+
+
+        block = blocks[0]
+        sample_set = [row.sample_id for row in block]
+
+        vcfline = vcfgenerator._line_block_to_vcf_line(block, sample_set)
+
+
+        assert vcfline._filter== ("FAIL",)
+        assert all(s["GT"] == "./." for s in vcfline.sample)


### PR DESCRIPTION
This PR introduces the following changes:
a. **FILTER logic for missing genotypes**
If all samples have missing genotypes at a given locus, the `FILTER` field is set to` FAIL`. If at least one sample has a called genotype, the `FILTER` remains `PASS`.
While the current script processes one sample at a time, it is capable of generating multi-sample VCFs. This change ensures that the filtering logic behaves correctly for both single-sample and multi-sample cases.

b. **Test coverage**
Four new tests have been added to the existing test suite to verify the above functionality. The tests scenarios as below
a. Single sample vcf with not called genotype
b. Single sample vcf with called genotype
c. Multisample vcf in which at least one sample has a called genotype
d. Multisample vcf with all samples without called genotypes.